### PR TITLE
Handling local relative path

### DIFF
--- a/archr/targets/local_target.py
+++ b/archr/targets/local_target.py
@@ -24,9 +24,11 @@ class LocalTarget(Target):
         if type(target_args) is str:
             target_args = [target_args]
         if target_path is None and target_args is not None:
-            target_path = target_args[0]
+            target_path = os.path.abspath(target_args[0])
         if type(target_path) is str:
             target_path = os.path.abspath(target_path)
+        if target_cwd is None and not os.path.isabs(target_args[0]):
+            target_cwd = os.path.dirname(os.path.abspath(target_args[0]))
         super().__init__(
             target_args=target_args,
             target_path=target_path,


### PR DESCRIPTION
I was having issues running things when I provided a relative path to local target. Basically, it was being passed through to the subprocessed commands and those were being run in the `/tmp` dir, which didn't have my binary.

This seems to fix the issue.