### PR TITLE
resolve_local_path() and resolve_glob() should support tmp_bind.

### DIFF
--- a/archr/targets/__init__.py
+++ b/archr/targets/__init__.py
@@ -252,7 +252,7 @@ class Target(ABC):
                 elif tmp_bind_prefix and g.startswith(tmp_bind_prefix):
                     fixed_paths.append(g[len(tmp_bind_prefix):])
                 else:
-                    raise ArchrError("Unexpected resolved local path %s. "
+                    raise ValueError("Unexpected resolved local path %s. "
                                      "It should start with either local_path or tmp_bind." % g)
             return fixed_paths
         except ArchrError:

--- a/archr/targets/__init__.py
+++ b/archr/targets/__init__.py
@@ -250,7 +250,7 @@ class Target(ABC):
                 if g.startswith(local_path_prefix):
                     fixed_paths.append(g[len(local_path_prefix)])
                 elif tmp_bind_prefix and g.startswith(tmp_bind_prefix):
-                    fixed_paths.append(g[len(tmp_bind_prefix):])
+                    fixed_paths.append(os.path.join("/tmp", g[len(tmp_bind_prefix):].lstrip("/")))
                 else:
                     raise ValueError("Unexpected resolved local path %s. "
                                      "It should start with either local_path or tmp_bind." % g)

--- a/archr/targets/docker_target.py
+++ b/archr/targets/docker_target.py
@@ -13,6 +13,7 @@ from . import Target
 
 os.system("mkdir -p /tmp/archr_mounts")
 _super_mount_cmd = "docker run --rm --privileged --mount type=bind,src=/tmp/archr_mounts/,target=/tmp/archr_mounts,bind-propagation=rshared --mount type=bind,src=/var/lib/docker,target=/var/lib/docker,bind-propagation=rshared ubuntu "
+
 class DockerImageTarget(Target):
     """
     Describes a target in the form of a Docker image.


### PR DESCRIPTION
This is because when tmp_bind is enabled, the guest directory /tmp/ will
be mapped to a new location outside of `local_path`. The tmp/ under
`local_path` is no longer valid.