### PR TITLE
Fixed a bug that was introduced in previous commit

### DIFF
--- a/archr/arsenal/angr_project.py
+++ b/archr/arsenal/angr_project.py
@@ -52,7 +52,7 @@ class angrProjectBow(Bow):
                 the_libs = { }
                 lib_opts = { }
                 bin_opts = { }
-            self._mem_mapping = { }
+                self._mem_mapping = { }
 
             if return_loader:
                 return cle.Loader(the_binary, preload_libs=the_libs, lib_opts=lib_opts, main_opts=bin_opts, **cle_args)


### PR DESCRIPTION
Commit 964af0a7d27f792fe1a442332c2cbb2c8056ba56 had a small indentation
based bug introduced which always reset the memory map to empty.