### PR TITLE
Fix docstring to reflect the correct bow

### DIFF
--- a/archr/arsenal/angr_project.py
+++ b/archr/arsenal/angr_project.py
@@ -10,7 +10,7 @@ from . import Bow
 
 class angrProjectBow(Bow):
     """
-    Describes a target in the form of a Docker image.
+    Constructs an angr project to match the target precisely
     """
 
     def __init__(self, target, scout_bow, static_simproc=False):


### PR DESCRIPTION
Found that the docstring didn't match the behavior at all while I was taking notes on archr's behavior.