### PR TITLE
Add option to pull image if it doesn't already exist

### DIFF
--- a/archr/targets/docker_target.py
+++ b/archr/targets/docker_target.py
@@ -54,7 +54,9 @@ class DockerImageTarget(Target):
     # Lifecycle
     #
 
-    def build(self):
+    def build(self, pull=False):
+        if pull and not self._client.images.list(self.image_id):
+            self._client.images.pull(self.image_id)
         self.image = self._client.images.get(self.image_id)
         self.target_args = (
             self.target_args or


### PR DESCRIPTION
The main use case I see for this is that if we have a central registry that containers need to pull from, we don't need to have an external extra step pulling before attempting to build a target. This shouldn't affect the default behaviour, and should ignore the option if the image is already downloaded.