### PR TITLE
Automatically stop docker targets when they are deleted

### DIFF
--- a/archr/targets/docker_target.py
+++ b/archr/targets/docker_target.py
@@ -293,6 +293,15 @@ class DockerImageTarget(Target):
             stdin=stdin, stdout=stdout, stderr=stderr, bufsize=0
         )
 
+    #
+    # Python magic
+    #
+
+    def __del__(self):
+        if self.rm:
+            self.stop()
+        return super().__del__()
+
 
 def check_in_docker() -> bool:
     with open("/proc/1/cgroup", "r") as f:


### PR DESCRIPTION
We have a few cases where people aren't properly stopping their containers, leaving a bunch of containers hanging on systems. This should take care of that by stopping containers when they are deleted in python.