### PR TITLE
Record syscall trace and "complete" trace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'archr': ['arrows/*.sh', 'arrows/*/*']
     },
     install_requires=[
-        'shellphish_qemu',
+        'shellphish_qemu>=0.10.0',
         'pygdbmi',
         'docker',
         'nclib>=1.0.0rc3',


### PR DESCRIPTION
This adds syscall_trace to QemuTraceResult:

```python
[(b'brk', (b'NULL',), 274880012288, b''),
 (b'uname', (274905180464,), 0, b''),
 (b'access',
  (b'"/etc/ld.so.nohwcap"', b'F_OK'),
  -1,
  b'errno=2 (No such file or directory)'),
 (b'access',
  (b'"/etc/ld.so.preload"', b'R_OK'),
  -1,
  b'errno=2 (No such file or directory)'),
 (b'openat', (-100, b'"/etc/ld.so.cache"', b'O_RDONLY|O_CLOEXEC'), 4, b''),
 (b'fstat', (4, 274905178912), 0, b''),
 (b'mmap',
  (b'NULL', 7274, b'PROT_READ', b'MAP_PRIVATE', 4, 0),
  274907459584,
  b''),
 (b'close', (4,), 0, b''),
 (b'access',
  (b'"/etc/ld.so.nohwcap"', b'F_OK'),
  -1,
  b'errno=2 (No such file or directory)'),
 (b'openat',
  (-100, b'"/lib/x86_64-linux-gnu/libc.so.6"', b'O_RDONLY|O_CLOEXEC'),
  4,
  b''),
 (b'read', (4, 27272424, 832), 832, b''),
 (b'fstat', (4, 274905179008), 0, b''),
 (b'mmap',
  (b'NULL',
   4131552,
   b'PROT_EXEC|PROT_READ',
   b'MAP_PRIVATE|MAP_DENYWRITE',
   4,
   0),
  274907467776,
  b''),
 (b'mprotect', (274909462528, 2097152, b'PROT_NONE'), 0, b''),
...
]
```

It also adds complete_trace, which interleaves basic block address (from the original trace) with syscalls.