### PR TITLE
DockerTarget: Initialize all attributes before start doing things.

### DIFF
--- a/archr/targets/docker_target.py
+++ b/archr/targets/docker_target.py
@@ -38,10 +38,15 @@ class DockerImageTarget(Target):
         else:
             self.tmp_bind = None
 
+        self.network = None
+        self.network_mode = None
+        self.image = None
+        self.container = None
+        self.volumes = { }
+        self.rm = rm
+
         if pull:
             self._pull()
-
-        self.rm = rm
 
         # If we're running in docker-by-docker, default the network to the same network
         if check_in_docker() and not check_dockerd_running() and network is None:
@@ -54,11 +59,8 @@ class DockerImageTarget(Target):
             except (KeyError, IndexError, docker.errors.APIError):
                 l.warning("Detected archr is being run from a docker container, but couldn't retrieve network information")
 
-        self.network_mode = network_mode if not network else None
         self.network = network
-        self.image = None
-        self.container = None
-        self.volumes = {}
+        self.network_mode = network_mode if not network else None
 
     #
     # Lifecycle


### PR DESCRIPTION
It fixes the following backtrace:

```
Traceback (most recent call last):
  File "/root/repos/slacrs6/slacrs/plugin_wrapper.py", line 74, in _handle_event_for_type
    c(event)
  File "/root/repos/slacrs6/slacrs/plugins/target_plugin.py", line 76, in on_new_requeted_target_event
    self.create_docker_target_description_from_request(request)
  File "/root/repos/slacrs6/slacrs/plugins/target_plugin.py", line 48, in create_docker_target_description_from_request
    raise e
  File "/root/repos/slacrs6/slacrs/plugins/target_plugin.py", line 43, in create_docker_target_description_from_request
    arch, md5, sha256 = get_info_from_image(name)
  File "/root/repos/slacrs6/slacrs/plugins/target_plugin.py", line 15, in get_info_from_image
    with archr.targets.DockerImageTarget(name, pull=True).build().start() as target:
  File "/root/repos/archr/archr/targets/docker_target.py", line 42, in __init__
    self._pull()
  File "/root/repos/archr/archr/targets/docker_target.py", line 301, in _pull
    self._client.images.pull(self.image_id)
  File "/root/venv/lib/python3.8/site-packages/docker/models/images.py", line 444, in pull
    pull_log = self.client.api.pull(
  File "/root/venv/lib/python3.8/site-packages/docker/api/image.py", line 415, in pull
    self._raise_for_status(response)
  File "/root/venv/lib/python3.8/site-packages/docker/api/client.py", line 263, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/root/venv/lib/python3.8/site-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
docker.errors.APIError: 500 Server Error: Internal Server Error ("Get http://localhost:5010/v2/: dial tcp 127.0.0.1:5010: connect: connection refused")
Exception ignored in: <function Target.__del__ at 0x7fa73fc3b940>
Traceback (most recent call last):
  File "/root/repos/archr/archr/targets/__init__.py", line 177, in __del__
    def __del__(self): self.remove()
  File "/root/repos/archr/archr/targets/docker_target.py", line 133, in remove
    if self.container:
AttributeError: 'DockerImageTarget' object has no attribute 'container'
```