### PR TITLE
ld-linux is not always the last library reported by ldd

### DIFF
--- a/archr/implants/emurrate/bundle
+++ b/archr/implants/emurrate/bundle
@@ -43,6 +43,6 @@ fi
 
 FIRE_SCRIPT=${0//bundle/fire}
 QEMU_LIBS=$(ldd ${QEMU_BINS[*]} | grep "=>" | awk '{print $3}' | sort -u)
-QEMU_LD=$(ldd ${QEMU_BINS[0]} | tail -n1 | awk '{print $1}')
+QEMU_LD=$(ldd ${QEMU_BINS[0]} | grep ld-linux | awk '{print $1}')
 cp -L ${QEMU_BINS[*]} $QEMU_LIBS $QEMU_LD $BUNDLE_DIR
 cp -L $FIRE_SCRIPT $BUNDLE_DIR/fire

--- a/archr/implants/shellphish_qemu/bundle
+++ b/archr/implants/shellphish_qemu/bundle
@@ -6,6 +6,6 @@ BUNDLE_DIR=$1
 FIRE_SCRIPT=${0//bundle/fire}
 QEMU_PATH=$(python -c "import shellphish_qemu; print(shellphish_qemu.qemu_base())")
 QEMU_LIBS=$(ldd $QEMU_PATH/* | grep "=>" | awk '{print $3}' | sort -u)
-QEMU_LD=$(ldd $QEMU_PATH/shellphish-qemu-cgc-base | tail -n1 | awk '{print $1}')
+QEMU_LD=$(ldd $QEMU_PATH/shellphish-qemu-cgc-base | fgrep ld-linux | awk '{print $1}')
 cp -L $QEMU_PATH/* $QEMU_LIBS $QEMU_LD $BUNDLE_DIR
 cp -L $FIRE_SCRIPT $BUNDLE_DIR/fire


### PR DESCRIPTION
On some systems (google colab) ld-linux is not last, and this prevents traces from being successfully recorded.

[Here is an example](https://colab.research.google.com/drive/1esPYHoJQW8lSHDQp30gNC-lMJVawBfGR?usp=sharing)