### PR TITLE
shellphish-qemu get latest version than pinning to 0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'archr': ['implants/*.sh', 'implants/*/*']
     },
     install_requires=[
-        'shellphish_qemu==0.11.0',
+        'shellphish_qemu',
         'pygdbmi',
         'docker',
         'nclib>=1.0.0rc3',


### PR DESCRIPTION
due to a version pinning to [shellphish-qemu:0.12.2](https://github.com/shellphish/shellphish-qemu/blob/master/setup.py#L194), angr-dev script failed. This PR tracks the latest version discarding the pinning and passed the pipeline. 

Error: 
```
ERROR: Could not find a version that satisfies the requirement shellphish_qemu==0.11.0 (from archr===9.0.gitrolling) (from versions: 0.9.8, 0.9.9, 0.9.10, 0.9.11)
ERROR: No matching distribution found for shellphish_qemu==0.11.0 (from archr===9.0.gitrolling)
```