### PR TITLE
taint_fd patch is not applied to cgc

### DIFF
--- a/archr/analyzers/qemu_tracer.py
+++ b/archr/analyzers/qemu_tracer.py
@@ -173,7 +173,8 @@ class QEMUTracerAnalyzer(ContextAnalyzer):
 
                 if r.crashed:
                     # grab the taint_fd
-                    if not endings[0].startswith(b"qemu: last read marker was read through fd:"):
+                    if not endings[0].startswith(b"qemu: last read marker was read through fd:") \
+                       and self.target.target_os != 'cgc':
                         l.error(
                             "Unexpected status line from qemu tracer. Cannot get the last read marker to set taint_fd. "
                             "Please make sure you are using the latest shellphish-qemu.")


### PR DESCRIPTION
this is the patch to suppress error messages in #88 .
taint_fd is a feature used in rex to for multi-stage exploitation. It records the interaction fd so the first payload(stager) knows where to read in the second payload