### PR TITLE
Fix qtrace testcases

### DIFF
--- a/tests/test_analyzer_qtrace.py
+++ b/tests/test_analyzer_qtrace.py
@@ -39,7 +39,7 @@ class TestAnalyzerQTrace(unittest.TestCase):
 
         mappings = {e[0].split("/")[-1] for e in machine.maps.values()}
         correct_mappings = {machine.argv[0].split("/")[-1], "[heap]", "[stack]"}
-        assert correct_mappings.issubset(mappings), (correct_mappings, mappings)
+        assert correct_mappings.issubset(mappings)
 
     def test_qtrace_local(self):
         with archr.targets.LocalTarget(["/bin/cat"]).build().start() as target:


### PR DESCRIPTION
I have no idea why it suddenly seems to have changed, but ubuntu:18.04 `/bin/cat` does not `LOAD` a read-only page, while ubuntu:20.04 `/bin/cat` does.

ubuntu:18.04:
```
Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  PHDR           0x0000000000000040 0x0000000000000040 0x0000000000000040
                 0x00000000000001f8 0x00000000000001f8  R E    0x8
  INTERP         0x0000000000000238 0x0000000000000238 0x0000000000000238
                 0x000000000000001c 0x000000000000001c  R      0x1
      [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x00000000000079d0 0x00000000000079d0  R E    0x200000
  LOAD           0x0000000000007a70 0x0000000000207a70 0x0000000000207a70
                 0x0000000000000650 0x00000000000007f0  RW     0x200000
  DYNAMIC        0x0000000000007c18 0x0000000000207c18 0x0000000000207c18
                 0x00000000000001f0 0x00000000000001f0  RW     0x8
  NOTE           0x0000000000000254 0x0000000000000254 0x0000000000000254
                 0x0000000000000044 0x0000000000000044  R      0x4
  GNU_EH_FRAME   0x0000000000006b64 0x0000000000006b64 0x0000000000006b64
                 0x0000000000000274 0x0000000000000274  R      0x4
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x10
  GNU_RELRO      0x0000000000007a70 0x0000000000207a70 0x0000000000207a70
                 0x0000000000000590 0x0000000000000590  R      0x1
```

ubuntu:20.04
```
Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  PHDR           0x0000000000000040 0x0000000000000040 0x0000000000000040
                 0x00000000000002d8 0x00000000000002d8  R      0x8
  INTERP         0x0000000000000318 0x0000000000000318 0x0000000000000318
                 0x000000000000001c 0x000000000000001c  R      0x1
      [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x00000000000016e0 0x00000000000016e0  R      0x1000
  LOAD           0x0000000000002000 0x0000000000002000 0x0000000000002000
                 0x0000000000004431 0x0000000000004431  R E    0x1000
  LOAD           0x0000000000007000 0x0000000000007000 0x0000000000007000
                 0x00000000000021d0 0x00000000000021d0  R      0x1000
  LOAD           0x0000000000009a90 0x000000000000aa90 0x000000000000aa90
                 0x0000000000000630 0x00000000000007c8  RW     0x1000
  DYNAMIC        0x0000000000009c38 0x000000000000ac38 0x000000000000ac38
                 0x00000000000001f0 0x00000000000001f0  RW     0x8
  NOTE           0x0000000000000338 0x0000000000000338 0x0000000000000338
                 0x0000000000000020 0x0000000000000020  R      0x8
  NOTE           0x0000000000000358 0x0000000000000358 0x0000000000000358
                 0x0000000000000044 0x0000000000000044  R      0x4
  GNU_PROPERTY   0x0000000000000338 0x0000000000000338 0x0000000000000338
                 0x0000000000000020 0x0000000000000020  R      0x8
  GNU_EH_FRAME   0x000000000000822c 0x000000000000822c 0x000000000000822c
                 0x00000000000002bc 0x00000000000002bc  R      0x4
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x10
  GNU_RELRO      0x0000000000009a90 0x000000000000aa90 0x000000000000aa90
                 0x0000000000000570 0x0000000000000570  R      0x1
```