### PR TITLE
Optimize QEMU trace log processing and basic block trace storage

### DIFF
--- a/archr/analyzers/qemu_tracer.py
+++ b/archr/analyzers/qemu_tracer.py
@@ -1,14 +1,14 @@
 import contextlib
+import glob
+import logging
+import mmap
+import os
+import re
+import shutil
+import signal
+import struct
 import subprocess
 import tempfile
-import logging
-import signal
-import shutil
-import glob
-import re
-import os
-import mmap
-import struct
 
 from io import BytesIO
 

--- a/archr/analyzers/qemu_tracer.py
+++ b/archr/analyzers/qemu_tracer.py
@@ -53,8 +53,7 @@ class QEMUBBLTrace:
     def count(self, element):
         count = 0
         for curr_index in range(0, self._trace_len):
-            curr_elem = self.__getitem__(curr_index)
-            if curr_elem == element:
+            if self[curr_index] == element:
                 count = count + 1
 
         return count
@@ -62,8 +61,7 @@ class QEMUBBLTrace:
     def index(self, element, start=0, stop=None):
         stop = stop if stop else self._trace_len
         for curr_index in range(start, stop):
-            curr_elem = self.__getitem__(curr_index)
-            if curr_elem == element:
+            if self[curr_index] == element:
                 return curr_index
 
         raise ValueError(f"{element} is not in trace")

--- a/archr/targets/__init__.py
+++ b/archr/targets/__init__.py
@@ -275,6 +275,14 @@ class Target(ABC):
             f.seek(0)
             self.inject_tarball("/", tarball_contents=f.read())
 
+    def copy_file(self, target_path, dst_path, dereference=False):
+        """
+        Copy file out from target
+
+        :param str target_path: File to copy out
+        :param str dst_path   : Destination of copy
+        """
+
     def retrieve_into(self, target_path, local_path):
         """
         Retrieves a path on the target into a path locally.

--- a/archr/targets/docker_target.py
+++ b/archr/targets/docker_target.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import tarfile
 import tempfile
 import logging
 import shlex
@@ -267,6 +268,18 @@ class DockerImageTarget(Target):
             p.stdout.close()
             if p.stderr:
                 p.stderr.close()
+
+    def copy_file(self, target_path, dst_path, dereference=False):
+        with tempfile.NamedTemporaryFile() as temp_archive:
+            with open(temp_archive, 'wb') as fh:
+                stream, _ = self.container.get_archive(target_path)
+                for content in stream:
+                    fh.write(content)
+
+            with open(temp_archive, 'rb') as fh:
+                with tarfile.open(fileobj=fh, mode='r') as t:
+                    os.makedirs(dst_path, exist_ok=True)
+                    t.extractall(dst_path, members=[target_path])
 
     def retrieve_tarball(self, target_path, dereference=False):
         stream, _ = self.container.get_archive(target_path)

--- a/archr/targets/local_target.py
+++ b/archr/targets/local_target.py
@@ -63,6 +63,9 @@ class LocalTarget(Target):
             os.makedirs(target_path)
         t.extractall(path=target_path)
 
+    def copy_file(self, target_path, dst_path, dereference=False):
+        shutil.copy(target_path, dst_path, follow_symlinks=dereference)
+
     def retrieve_tarball(self, target_path, dereference=False):
         f = io.BytesIO()
         t = tarfile.TarFile(fileobj=f, mode="w", dereference=dereference)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     patchelf-wrapper
     cle==9.2.28.dev0
     ply
+    numpy
 
 python_requires = >= 3.6
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ install_requires =
     patchelf-wrapper
     cle==9.2.28.dev0
     ply
-    numpy
 
 python_requires = >= 3.6
 include_package_data = True


### PR DESCRIPTION
This PR makes two key changes:

1. Read QEMU trace log line by line instead of reading all lines into memory and then iterating over them. This is useful in case the trace log is very large.
2. Store basic block trace in a memory mapped file. This enables working with very long basic block traces. This is done using [numpy's memmap](https://numpy.org/doc/stable/reference/generated/numpy.memmap.html).

This PR requires changes being introduced in angr/angr#3648. I ran tests using nose(with those changes in angr as well) and among all tests that run by default, all tests passing on master also pass with these changes and so I think we can merge this in.