### PR TITLE
Fix file leak in QEMU tracer

### DIFF
--- a/archr/analyzers/qemu_tracer.py
+++ b/archr/analyzers/qemu_tracer.py
@@ -243,9 +243,9 @@ class QEMUTracerAnalyzer(ContextAnalyzer):
                     r.halfway_core_path = local_halfway_core_filename
 
             if target_trace_filename:
-                temp_trace_file = tempfile.mktemp(dir="/tmp", prefix="tracer-")
-                self.target.copy_file(target_trace_filename, temp_trace_file)
-                trace_fh = open(temp_trace_file, "rb")
+                temp_trace_file = tempfile.NamedTemporaryFile()
+                self.target.copy_file(target_trace_filename, temp_trace_file.name)
+                trace_fh = open(temp_trace_file.name, "rb")
 
                 # Find where qemu loaded the binary. Primarily for PIE
                 try:
@@ -303,6 +303,8 @@ class QEMUTracerAnalyzer(ContextAnalyzer):
 
                 lastline = entry
                 bbl_trace_fh.close()
+                trace_fh.close()
+                temp_trace_file.close()
                 r.trace = QEMUBBLTrace(bbl_trace_file.name, bbl_trace_len)
 
                 if r.crashed:


### PR DESCRIPTION
Currently, `mktemp` is used to get name of a temporary file to which the QEMU output file from taregt is copied to. However, this file is never cleaned up and `mktemp` seems to be [deprecated](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). This PR replaces `mktemp` with a `NamedTemporaryFile` that is cleaned up at the end. All CI runners seem to have failing test cases on master so I'm guessing I didn't break anything with this change.