### PR TITLE
Update minimum cmake to 3.5

### DIFF
--- a/archr/implants/udp_tcp_convert/CMakeLists.txt
+++ b/archr/implants/udp_tcp_convert/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.22)
+cmake_minimum_required (VERSION 3.0)
 project (udp_to_tcp)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/archr/implants/udp_tcp_convert/CMakeLists.txt
+++ b/archr/implants/udp_tcp_convert/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.5)
 project (udp_to_tcp)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
Cmake 4 came out, breaking the build as 2.22 is no longer supported.

3.5 is the oldest supported currently: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html